### PR TITLE
apple/swift-syntax 5.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "branch" : "508.0.0",
-        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd"
       }
     },
     {
@@ -43,6 +41,8 @@
       "state" : {
         "revision" : "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
         "version" : "0.5.2"
+        "branch" : "509.0.0",
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,37 +10,10 @@
       }
     },
     {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format.git",
-      "state" : {
-        "branch" : "508.0.0",
-        "revision" : "3330aaa0a97fe07e764a4dc9bb032b23df3a948f"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-tools-support-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-tools-support-core.git",
-      "state" : {
-        "revision" : "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
-        "version" : "0.5.2"
         "branch" : "509.0.0",
         "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b"
       }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-format.git", revision: "508.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax.git", revision: "508.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", revision: "509.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-format.git", revision: "508.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-syntax.git", revision: "509.0.0"),
     ],
@@ -25,7 +24,6 @@ let package = Package(
                 .target(name: "LexiconGenKit"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-                .product(name: "SwiftFormat", package: "swift-format"),
             ]
         ),
         .target(


### PR DESCRIPTION
- Bump up apple/swift-syntax to 5.9
- Remove apple/swift-format which is no longer needed